### PR TITLE
[CORE-2799] Upload prebuild artifacts to S3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,17 @@ jobs:
         with:
           path: artifacts
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Upload artifacts to S3
+        run: |
+          aws s3 cp artifacts/ s3://harper-artifacts/rocksdb-prebuilds/v${{ needs.check.outputs.version }}/ --recursive
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
Uploads the artifacts to S3 along with GitHub releases. Downloading assets from GitHub releases are rate limited and can cause CI to fail.

JIRA: https://harperdb.atlassian.net/browse/CORE-2799